### PR TITLE
[NO TICKET] Disable block cache.

### DIFF
--- a/src/Plugin/Block/TwitterFeedBlock.php
+++ b/src/Plugin/Block/TwitterFeedBlock.php
@@ -139,6 +139,13 @@ class TwitterFeedBlock extends BlockBase implements ContainerFactoryPluginInterf
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
+  }
+
   private function getBearerToken() {
     $config = \Drupal::config('twitter_feed.settings');
 


### PR DESCRIPTION
Disable block cache so that the tweed feed can be updated instantly when there is new tweet.

This is related to the following JIRA issue:
- https://digital-engagement.atlassian.net/browse/SDPD8-613
